### PR TITLE
SCAL-71: Only add no_cursor_timeout if present as cursor args

### DIFF
--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1514,9 +1514,11 @@ class BaseQuerySet(object):
             if self._snapshot:
                 msg = 'The snapshot option is not anymore available with PyMongo 3+'
                 warnings.warn(msg, DeprecationWarning)
-            cursor_args = {
-                'no_cursor_timeout': not self._timeout
-            }
+
+            cursor_args = {}
+            if not self._timeout:
+                cursor_args["no_cursor_timeout"] = True
+
         if self._loaded_fields:
             cursor_args[fields_name] = self._loaded_fields.as_dict()
 


### PR DESCRIPTION
This is a port of https://github.com/MongoEngine/mongoengine/pull/2160 to our fork to avoid errors in MongoDB 4.2

