### PR TITLE
Reset fork to v.23 and fix validation of inc and dec for an IntField with min_value

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -188,7 +188,7 @@ class BaseField:
 
     def prepare_query_value(self, op, value):
         """Prepare a value that is being used in a query for PyMongo."""
-        if op in UPDATE_OPERATORS:
+        if op in UPDATE_OPERATORS and op != "inc":
             self.validate(value)
         return value
 

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -47,7 +47,7 @@ class TestDocumentInstance(MongoDBTestCase):
 
         class Person(Document):
             name = StringField()
-            age = IntField()
+            age = IntField(min_value=0)
             job = EmbeddedDocumentField(Job)
 
             non_field = True
@@ -964,6 +964,24 @@ class TestDocumentInstance(MongoDBTestCase):
         assert doc._get_changed_fields() == []
 
         self.assertDbEqual([dict(other_doc.to_mongo()), dict(doc.to_mongo())])
+
+    def test_modify_increment(self):
+        doc1 = self.Person(name="bob", age=10).save()
+
+        n_modified = doc1.modify(inc__age=1)
+        assert n_modified == 1
+        assert doc1.age == 11
+
+        assert self.Person._get_collection().find_one({"_id": doc1.pk})["age"] == 11
+
+    def test_modify_decrement(self):
+        doc1 = self.Person(name="bob", age=10).save()
+
+        n_modified = doc1.modify(dec__age=1)
+        assert n_modified == 1
+        assert doc1.age == 9
+
+        assert self.Person._get_collection().find_one({"_id": doc1.pk})["age"] == 9
 
     def test_modify_with_positional_push(self):
         class Content(EmbeddedDocument):


### PR DESCRIPTION
Why do you see this PR?

I am checking if there is a simple way to get the benefits of latest mongoengine in our code before working on transactions. I am studying it, because implementing transactions in our old version of the fork was a bit more complicated because of bajcward compatibilty, old versions of MongoDB, pymongo, ...

The good news, it is possible but there is a bug in mongoengine.

Branch v23 contains the latest released of mongoengine in version 0.23
This PR is a fix on the validation they are doing for IntFields with min_value that affects our code when we reduce the balance of a user.

Probably there are better ways to fix it, so feedback is appreciated and if someone wants to make sure this fix goes to the upstream I would be happy to help anonymously.