### PR TITLE
TRU-2836: Tests concurrency for run_in_transaction

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,13 @@ Development
 ===========
 - (Fill this out as you fix issues and develop your features).
 
+Changes in 0.23.1 (Prolific
+===========
+- TRU-2836: Make session thread-safe
+- Bugfix: Ensure queryset create, update and delete run in a transaction
+- SCAL-104: Add run_in_transaction  context manager and decorator
+- Skip validation of inc and dec for an IntField with min_value
+
 Changes in 0.23.0
 ===========
 - Bugfix: manually setting SequenceField in DynamicDocument doesn't increment the counter #2471

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -28,7 +28,7 @@ __all__ = (
 )
 
 
-VERSION = (0, 23, 0)
+VERSION = (0, 23, 1)
 
 
 def get_version():

--- a/mongoengine/sessions.py
+++ b/mongoengine/sessions.py
@@ -1,29 +1,33 @@
+import threading
 from typing import Optional
 
 from pymongo.client_session import ClientSession
 
 from mongoengine.connection import DEFAULT_CONNECTION_NAME
 
-_sessions = {}
+_sessions = threading.local()
 
 
 def set_local_session(db_alias: str, session: ClientSession):
-    _sessions[key_local_session(db_alias)] = session
+    _sessions.__setattr__(key_local_session(db_alias), session)
 
 
 def get_local_session(
     db_alias: str = DEFAULT_CONNECTION_NAME,
 ) -> Optional[ClientSession]:
-    return _sessions.get(key_local_session(db_alias))
+    try:
+        return _sessions.__getattribute__(key_local_session(db_alias))
+    except AttributeError:
+        return None
 
 
 def clear_local_session(db_alias: str = DEFAULT_CONNECTION_NAME):
-    _sessions.pop(key_local_session(db_alias), None)
+    _sessions.__delattr__(key_local_session(db_alias))
 
 
 def clear_all():
     global _sessions
-    _sessions = {}
+    _sessions = threading.local()
 
 
 def key_local_session(db_alias):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,103 @@
+import threading
+import unittest
+from random import uniform
+from time import sleep
+
+from mongoengine import Document, IntField, OperationError, StringField
+from mongoengine.context_managers import run_in_transaction
+from tests.utils import MongoDBTestCase
+
+
+class ConcurrencyTest(MongoDBTestCase):
+    @staticmethod
+    def test_multiple_threads_modifying_different_instances():
+        doc1 = Article(title="doc1", views=0).save()
+        doc2 = Article(title="doc2", views=0).save()
+        doc3 = Article(title="doc3", views=0).save()
+        doc4 = Article(title="doc4", views=0).save()
+
+        run_threads(
+            [
+                threading.Thread(
+                    target=doc1.increase_views,
+                ),
+                threading.Thread(
+                    target=doc2.increase_views,
+                    args=(True,),
+                ),
+                threading.Thread(
+                    target=doc3.increase_views,
+                ),
+                threading.Thread(
+                    target=doc4.increase_views,
+                    args=(True,),
+                ),
+            ]
+        )
+
+        doc1.reload()
+        doc2.reload()
+        doc3.reload()
+        doc4.reload()
+        assert doc1.views == 1
+        assert doc2.views == 0
+        assert doc3.views == 1
+        assert doc4.views == 0
+
+    @staticmethod
+    def test_multiple_threads_modifying_same_instance():
+        doc1 = Article(title="doc1", views=0).save()
+        expected_views = 80
+
+        threads = []
+        for _ in range(0, expected_views):
+            threads += [
+                threading.Thread(
+                    target=doc1.increase_views,
+                ),
+                threading.Thread(
+                    target=doc1.increase_views,
+                    args=(True,),
+                ),
+            ]
+
+        run_threads(threads)
+
+        doc1.reload()
+        assert doc1.views == expected_views
+
+
+class CustomException(Exception):
+    pass
+
+
+class Article(Document):
+    title = StringField()
+    views = IntField()
+
+    def increase_views(self, raise_exception: bool = False):
+        try:
+            with run_in_transaction():
+                self.modify(inc__views=1)
+                if raise_exception:
+                    raise CustomException("test")
+        except CustomException:
+            # Do nothing
+            pass
+        except OperationError:
+            # Retry on Operation Error
+            sleep(uniform(0, 3))
+            self.increase_views(raise_exception)
+
+
+def run_threads(threads):
+    # Start them all at the same time
+    for thread in threads:
+        thread.start()
+    # Wait for all to complete
+    for thread in threads:
+        thread.join()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I am trying to reproduce what Oli found in the main project.
It did not fail all the time but it could be reproduced and the issue is that the session was not thread-safe.
That should not be an issue in production as we use unicorn and that spawns a process per thread, thus making our global session local to that thread. 
But it makes things easier to test and allows other server approaches based on threads. 